### PR TITLE
Set legacy build system setting for Xcode 10

### DIFF
--- a/todo/flutter/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/todo/flutter/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
Flutter currently does not support the new build system on Xcode 10 https://github.com/flutter/flutter/issues/20685